### PR TITLE
修复一个构造器注入的bug，同时增加支持构造器值注入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/src/main/java/com/xilidou/framework/ioc/bean/ConstructorArg.java
+++ b/src/main/java/com/xilidou/framework/ioc/bean/ConstructorArg.java
@@ -11,5 +11,5 @@ public class ConstructorArg {
     private int index;
     private String ref;
     private String name;
-
+    private Object value;
 }

--- a/src/main/java/com/xilidou/framework/ioc/bean/PropertyArg.java
+++ b/src/main/java/com/xilidou/framework/ioc/bean/PropertyArg.java
@@ -1,5 +1,8 @@
 package com.xilidou.framework.ioc.bean;
 
+import lombok.Data;
+
+@Data
 public class PropertyArg {
 
     private String name;

--- a/src/main/java/com/xilidou/framework/ioc/core/BeanFactoryImpl.java
+++ b/src/main/java/com/xilidou/framework/ioc/core/BeanFactoryImpl.java
@@ -7,9 +7,11 @@ import com.xilidou.framework.ioc.utils.ClassUtils;
 import com.xilidou.framework.ioc.utils.ReflectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class BeanFactoryImpl implements BeanFactory{
 
@@ -57,11 +59,17 @@ public class BeanFactoryImpl implements BeanFactory{
         if(constructorArgs != null && !constructorArgs.isEmpty()){
             List<Object> objects = new ArrayList<>();
             for (ConstructorArg constructorArg : constructorArgs) {
-                objects.add(getBean(constructorArg.getRef()));
+                if (constructorArg.getValue() != null) {
+                    objects.add(constructorArg.getValue());
+                } else {
+                    objects.add(getBean(constructorArg.getRef()));
+                }
             }
-            return BeanUtils.instanceByCglib(clz,clz.getConstructor(),objects.toArray());
-        }else {
-            return BeanUtils.instanceByCglib(clz,null,null);
+            Class[] constructorArgTypes = objects.stream().map(it -> it.getClass()).collect(Collectors.toList()).toArray(new Class[]{});
+            Constructor constructor = clz.getConstructor(constructorArgTypes);
+            return BeanUtils.instanceByCglib(clz, constructor, objects.toArray());
+        } else {
+            return BeanUtils.instanceByCglib(clz, null, null);
         }
     }
 

--- a/src/test/java/com/xilidou/framework/ioc/entity/Mouth.java
+++ b/src/test/java/com/xilidou/framework/ioc/entity/Mouth.java
@@ -2,7 +2,11 @@ package com.xilidou.framework.ioc.entity;
 
 public class Mouth {
 
-    public void speak(){
+    public Mouth(String name) {
+
+    }
+
+    public void speak() {
 
         System.out.println("say hello world");
 

--- a/src/test/resources/application.json
+++ b/src/test/resources/application.json
@@ -1,15 +1,22 @@
 [
   {
-    "name":"robot",
-    "className":"com.xilidou.framework.ioc.entity.Robot"
+    "name": "robot",
+    "className": "com.xilidou.framework.ioc.entity.Robot"
   },
   {
-    "name":"hand",
-    "className":"com.xilidou.framework.ioc.entity.Hand"
+    "name": "hand",
+    "className": "com.xilidou.framework.ioc.entity.Hand"
   },
   {
-    "name":"mouth",
-    "className":"com.xilidou.framework.ioc.entity.Mouth"
+    "name": "mouth",
+    "className": "com.xilidou.framework.ioc.entity.Mouth",
+    "constructorArgs": [
+      {
+        "index": 1,
+        "name": "name",
+        "value": "hello"
+      }
+    ]
   }
 ]
 


### PR DESCRIPTION
代码写得很棒，一下子就看懂了，加深了对Spring源码的认识同时也发现了一个小问题
原代码在构造器注入的时候，获取的是默认的无参构造器， 见以下代码
`return BeanUtils.instanceByCglib(clz,clz.getConstructor(),objects.toArray());`
实际上构造器注入的时候应该获取与参数相对应的构造器，在合并的代码中修复了这个bug
所以，提交一个pull request，希望可以合并进去